### PR TITLE
[fix] fetch 오류로 인한 이미지 저장 불가 현상 수정

### DIFF
--- a/src/components/ImageAsset.tsx
+++ b/src/components/ImageAsset.tsx
@@ -6,7 +6,7 @@ import type { ImageAssetType } from "../types/assets";
 import AssetWrapper from "./AssetWrapper";
 import BackgroundControl, { getBackgroundStyle } from "./BackgroundControl";
 import SliderControl from "./SliderControl";
-import { fileToDataUrl } from "../utils/fileToDataUrl";
+import { useImageUpload } from "../hooks/useImageUpload";
 
 interface ImageAssetProps {
   asset: ImageAssetType;
@@ -15,6 +15,16 @@ interface ImageAssetProps {
 function ImageToolbar({ asset }: { asset: ImageAssetType }) {
   const { updateAsset } = useAssets();
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const { handleImageUpload } = useImageUpload({
+    onSuccess: (url) => updateAsset(asset.id, { url }),
+    onError: (error) => {
+      console.error("Asset image replacement failed:", error);
+      alert(
+        "이미지 교체에 실패했습니다. 손상되지 않은 유효한 이미지인지 확인 후 다시 시도해주세요.",
+      );
+    },
+  });
 
   return (
     <div className="min-w-[260px]">
@@ -99,20 +109,7 @@ function ImageToolbar({ asset }: { asset: ImageAssetType }) {
         ref={fileInputRef}
         type="file"
         accept="image/*"
-        onChange={async (e) => {
-          const file = e.target.files?.[0];
-          if (file) {
-            try {
-              const url = await fileToDataUrl(file);
-              updateAsset(asset.id, { url });
-            } catch (error) {
-              console.error("Asset image replacement failed:", error);
-              alert(
-                "이미지 교체에 실패했습니다. 손상되지 않은 유효한 이미지인지 확인 후 다시 시도해주세요.",
-              );
-            }
-          }
-        }}
+        onChange={handleImageUpload}
         className="hidden"
       />
     </div>

--- a/src/components/ImageAsset.tsx
+++ b/src/components/ImageAsset.tsx
@@ -6,6 +6,7 @@ import type { ImageAssetType } from "../types/assets";
 import AssetWrapper from "./AssetWrapper";
 import BackgroundControl, { getBackgroundStyle } from "./BackgroundControl";
 import SliderControl from "./SliderControl";
+import { fileToDataUrl } from "../utils/fileToDataUrl";
 
 interface ImageAssetProps {
   asset: ImageAssetType;
@@ -98,9 +99,12 @@ function ImageToolbar({ asset }: { asset: ImageAssetType }) {
         ref={fileInputRef}
         type="file"
         accept="image/*"
-        onChange={(e) => {
+        onChange={async (e) => {
           const file = e.target.files?.[0];
-          if (file) updateAsset(asset.id, { url: URL.createObjectURL(file) });
+          if (file) {
+            const url = await fileToDataUrl(file);
+            updateAsset(asset.id, { url });
+          }
         }}
         className="hidden"
       />

--- a/src/components/ImageAsset.tsx
+++ b/src/components/ImageAsset.tsx
@@ -102,8 +102,15 @@ function ImageToolbar({ asset }: { asset: ImageAssetType }) {
         onChange={async (e) => {
           const file = e.target.files?.[0];
           if (file) {
-            const url = await fileToDataUrl(file);
-            updateAsset(asset.id, { url });
+            try {
+              const url = await fileToDataUrl(file);
+              updateAsset(asset.id, { url });
+            } catch (error) {
+              console.error("Asset image replacement failed:", error);
+              alert(
+                "이미지 교체에 실패했습니다. 손상되지 않은 유효한 이미지인지 확인 후 다시 시도해주세요.",
+              );
+            }
           }
         }}
         className="hidden"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -434,8 +434,15 @@ export default function Sidebar({ className }: SidebarProps) {
                           onChange={async (e) => {
                             const file = e.target.files?.[0];
                             if (file) {
-                              const url = await fileToDataUrl(file);
-                              updateSettings({ backgroundImage: url });
+                              try {
+                                const url = await fileToDataUrl(file);
+                                updateSettings({ backgroundImage: url });
+                              } catch (error) {
+                                console.error("Background image upload failed:", error);
+                                alert(
+                                  "배경 이미지 업로드에 실패했습니다. 손상되지 않은 유효한 이미지인지 확인 후 다시 시도해주세요.",
+                                );
+                              }
                             }
                             e.target.value = "";
                           }}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -13,7 +13,7 @@ import {
 } from "lucide-react";
 import clsx from "clsx";
 import SliderControl from "./SliderControl";
-import { fileToDataUrl } from "../utils/fileToDataUrl";
+import { useImageUpload } from "../hooks/useImageUpload";
 import type { CanvasOrientation, TemplateType } from "../types/canvas";
 
 interface SidebarProps {
@@ -29,6 +29,15 @@ export default function Sidebar({ className }: SidebarProps) {
   const { addAsset, addSticker, clearAll } = useAssets();
   const [activeTab, setActiveTab] = useState<"info" | "settings">("settings");
   const bgImageInputRef = useRef<HTMLInputElement>(null);
+  const { handleImageUpload: handleBgUpload } = useImageUpload({
+    onSuccess: (url) => updateSettings({ backgroundImage: url }),
+    onError: (error) => {
+      console.error("Background image upload failed:", error);
+      alert(
+        "배경 이미지 업로드에 실패했습니다. 손상되지 않은 유효한 이미지인지 확인 후 다시 시도해주세요.",
+      );
+    },
+  });
 
   const handleModeChange = (mode: "template" | "free") => {
     if (settings.mode === mode) return;
@@ -431,21 +440,7 @@ export default function Sidebar({ className }: SidebarProps) {
                           type="file"
                           ref={bgImageInputRef}
                           accept="image/*"
-                          onChange={async (e) => {
-                            const file = e.target.files?.[0];
-                            if (file) {
-                              try {
-                                const url = await fileToDataUrl(file);
-                                updateSettings({ backgroundImage: url });
-                              } catch (error) {
-                                console.error("Background image upload failed:", error);
-                                alert(
-                                  "배경 이미지 업로드에 실패했습니다. 손상되지 않은 유효한 이미지인지 확인 후 다시 시도해주세요.",
-                                );
-                              }
-                            }
-                            e.target.value = "";
-                          }}
+                          onChange={handleBgUpload}
                           className="hidden"
                         />
                       </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import clsx from "clsx";
 import SliderControl from "./SliderControl";
+import { fileToDataUrl } from "../utils/fileToDataUrl";
 import type { CanvasOrientation, TemplateType } from "../types/canvas";
 
 interface SidebarProps {
@@ -430,10 +431,10 @@ export default function Sidebar({ className }: SidebarProps) {
                           type="file"
                           ref={bgImageInputRef}
                           accept="image/*"
-                          onChange={(e) => {
+                          onChange={async (e) => {
                             const file = e.target.files?.[0];
                             if (file) {
-                              const url = URL.createObjectURL(file);
+                              const url = await fileToDataUrl(file);
                               updateSettings({ backgroundImage: url });
                             }
                             e.target.value = "";

--- a/src/components/StickerAsset.tsx
+++ b/src/components/StickerAsset.tsx
@@ -20,6 +20,7 @@ import clsx from "clsx";
 import SliderControl from "./SliderControl";
 import BackgroundControl, { getBackgroundStyle } from "./BackgroundControl";
 import DraggablePopover from "./DraggablePopover";
+import { fileToDataUrl } from "../utils/fileToDataUrl";
 
 // 말풍선 꼬리 CSS 속성 생성 유틸리티
 function getTailStyle(
@@ -151,10 +152,10 @@ export default function StickerAsset({
   };
 
   // ── 이미지 업로드 ──────────────────────────────────────
-  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    const url = URL.createObjectURL(file);
+    const url = await fileToDataUrl(file);
     updateSticker(sticker.id, { url });
     e.target.value = "";
   };

--- a/src/components/StickerAsset.tsx
+++ b/src/components/StickerAsset.tsx
@@ -155,8 +155,15 @@ export default function StickerAsset({
   const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    const url = await fileToDataUrl(file);
-    updateSticker(sticker.id, { url });
+    try {
+      const url = await fileToDataUrl(file);
+      updateSticker(sticker.id, { url });
+    } catch (error) {
+      console.error("Sticker image upload failed:", error);
+      alert(
+        "스티커 이미지 업로드에 실패했습니다. 손상되지 않은 유효한 이미지인지 확인 후 다시 시도해주세요.",
+      );
+    }
     e.target.value = "";
   };
 

--- a/src/components/StickerAsset.tsx
+++ b/src/components/StickerAsset.tsx
@@ -20,7 +20,7 @@ import clsx from "clsx";
 import SliderControl from "./SliderControl";
 import BackgroundControl, { getBackgroundStyle } from "./BackgroundControl";
 import DraggablePopover from "./DraggablePopover";
-import { fileToDataUrl } from "../utils/fileToDataUrl";
+import { useImageUpload } from "../hooks/useImageUpload";
 
 // 말풍선 꼬리 CSS 속성 생성 유틸리티
 function getTailStyle(
@@ -152,21 +152,17 @@ export default function StickerAsset({
   };
 
   // ── 이미지 업로드 ──────────────────────────────────────
-  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    try {
-      const url = await fileToDataUrl(file);
-      updateSticker(sticker.id, { url });
-    } catch (error) {
+  const { handleImageUpload: handleFile } = useImageUpload({
+    onSuccess: (url) => updateSticker(sticker.id, { url }),
+    onError: (error) => {
       console.error("Sticker image upload failed:", error);
       alert(
         "스티커 이미지 업로드에 실패했습니다. 손상되지 않은 유효한 이미지인지 확인 후 다시 시도해주세요.",
       );
-    }
-    e.target.value = "";
-  };
+    },
+  });
 
+  // ── Popover Toggles ────────────────────────────────────
   return (
     <>
       <div

--- a/src/components/TemplateZone.tsx
+++ b/src/components/TemplateZone.tsx
@@ -44,8 +44,15 @@ export default function TemplateZone({
   const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
-      const url = await fileToDataUrl(file);
-      handleAdd("image", undefined, { url });
+      try {
+        const url = await fileToDataUrl(file);
+        handleAdd("image", undefined, { url });
+      } catch (error) {
+        console.error("Template zone image upload failed:", error);
+        alert(
+          "이미지 업로드에 실패했습니다. 손상되지 않은 유효한 이미지인지 확인 후 다시 시도해주세요.",
+        );
+      }
     }
     if (fileInputRef.current) {
       fileInputRef.current.value = "";

--- a/src/components/TemplateZone.tsx
+++ b/src/components/TemplateZone.tsx
@@ -1,16 +1,16 @@
-import { useState, useRef } from "react";
+import { ImageIcon, Palette, Plus, Type } from "lucide-react";
+import { useRef, useState } from "react";
+import { useImageUpload } from "../hooks/useImageUpload";
 import { useAssets } from "../store/AssetContext";
-import type { AssetType } from "../types/assets";
 import type {
+  AssetType,
   ImageAssetType,
-  TextAssetType,
   PaletteAssetType,
+  TextAssetType,
 } from "../types/assets";
+import ColorPaletteAsset from "./ColorPaletteAsset";
 import ImageAsset from "./ImageAsset";
 import TextAsset from "./TextAsset";
-import ColorPaletteAsset from "./ColorPaletteAsset";
-import { ImageIcon, Palette, Plus, Type } from "lucide-react";
-import { fileToDataUrl } from "../utils/fileToDataUrl";
 
 interface TemplateZoneProps {
   slotId: string;
@@ -41,23 +41,15 @@ export default function TemplateZone({
     setShowPicker(false);
   };
 
-  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      try {
-        const url = await fileToDataUrl(file);
-        handleAdd("image", undefined, { url });
-      } catch (error) {
-        console.error("Template zone image upload failed:", error);
-        alert(
-          "이미지 업로드에 실패했습니다. 손상되지 않은 유효한 이미지인지 확인 후 다시 시도해주세요.",
-        );
-      }
-    }
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
-    }
-  };
+  const { handleImageUpload: handleImageChange } = useImageUpload({
+    onSuccess: (url) => handleAdd("image", undefined, { url }),
+    onError: (error) => {
+      console.error("Template zone image upload failed:", error);
+      alert(
+        "이미지 업로드에 실패했습니다. 손상되지 않은 유효한 이미지인지 확인 후 다시 시도해주세요.",
+      );
+    },
+  });
 
   // 에셋이 있으면 AssetWrapper가 내장된 각 컴포넌트를 그대로 렌더링
   // (X 버튼, 툴바는 AssetWrapper가 제공)

--- a/src/components/TemplateZone.tsx
+++ b/src/components/TemplateZone.tsx
@@ -10,6 +10,7 @@ import ImageAsset from "./ImageAsset";
 import TextAsset from "./TextAsset";
 import ColorPaletteAsset from "./ColorPaletteAsset";
 import { ImageIcon, Palette, Plus, Type } from "lucide-react";
+import { fileToDataUrl } from "../utils/fileToDataUrl";
 
 interface TemplateZoneProps {
   slotId: string;
@@ -40,10 +41,11 @@ export default function TemplateZone({
     setShowPicker(false);
   };
 
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
-      handleAdd("image", undefined, { url: URL.createObjectURL(file) });
+      const url = await fileToDataUrl(file);
+      handleAdd("image", undefined, { url });
     }
     if (fileInputRef.current) {
       fileInputRef.current.value = "";

--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -1,0 +1,41 @@
+import { fileToDataUrl } from "../utils/fileToDataUrl";
+
+interface UseImageUploadOptions {
+  onSuccess: (url: string) => void;
+  onError?: (error: unknown) => void;
+}
+
+/**
+ * 이미지 업로드 및 Base64 변환 공통 로직을 처리하는 훅
+ */
+export function useImageUpload({ onSuccess, onError }: UseImageUploadOptions) {
+  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    
+    // 파일이 없으면 그냥 리셋 후 종료
+    if (!file) {
+      e.target.value = "";
+      return;
+    }
+
+    try {
+      const url = await fileToDataUrl(file);
+      onSuccess(url);
+    } catch (error) {
+      console.error("Image upload failed:", error);
+      if (onError) {
+        onError(error);
+      } else {
+        // 기본 에러 처리
+        alert(
+          "이미지 처리 중 오류가 발생했습니다. 손상되지 않은 유효한 이미지인지 확인 후 다시 시도해주세요."
+        );
+      }
+    } finally {
+      // 동일한 파일을 연속으로 업로드할 수 있도록 input value 초기화
+      e.target.value = "";
+    }
+  };
+
+  return { handleImageUpload };
+}

--- a/src/store/AssetContext.tsx
+++ b/src/store/AssetContext.tsx
@@ -93,16 +93,7 @@ export function AssetProvider({ children }: { children: ReactNode }) {
 
   const removeAsset = useCallback((id: string) => {
     Sentry.captureMessage(`remove asset`);
-    setAssets((prev) => {
-      const assetToRemove = prev.find((a) => a.id === id);
-      if (
-        assetToRemove?.type === "image" &&
-        assetToRemove.url.startsWith("blob:")
-      ) {
-        URL.revokeObjectURL(assetToRemove.url);
-      }
-      return prev.filter((a) => a.id !== id);
-    });
+    setAssets((prev) => prev.filter((a) => a.id !== id));
     setFreeAssets((prev) => prev.filter((a) => a.assetId !== id));
     setTemplateSlots((prev) => {
       const next = { ...prev };
@@ -168,34 +159,15 @@ export function AssetProvider({ children }: { children: ReactNode }) {
 
   const removeSticker = useCallback((id: string) => {
     Sentry.captureMessage(`remove sticker`);
-    setStickerAssets((prev) => {
-      const stickerToRemove = prev.find((s) => s.id === id);
-      if (
-        stickerToRemove?.stickerType === "image" &&
-        stickerToRemove.url.startsWith("blob:")
-      ) {
-        URL.revokeObjectURL(stickerToRemove.url);
-      }
-      return prev.filter((s) => s.id !== id);
-    });
+    setStickerAssets((prev) => prev.filter((s) => s.id !== id));
   }, []);
 
   const clearAll = useCallback(() => {
-    assets.forEach((a) => {
-      if (a.type === "image" && a.url.startsWith("blob:")) {
-        URL.revokeObjectURL(a.url);
-      }
-    });
-    stickerAssets.forEach((s) => {
-      if (s.stickerType === "image" && s.url.startsWith("blob:")) {
-        URL.revokeObjectURL(s.url);
-      }
-    });
     setAssets([]);
     setFreeAssets([]);
     setTemplateSlots({});
     setStickerAssets([]);
-  }, [assets, stickerAssets]);
+  }, []);
 
   return (
     <AssetContext.Provider

--- a/src/store/CanvasSettingsContext.tsx
+++ b/src/store/CanvasSettingsContext.tsx
@@ -38,27 +38,10 @@ export function CanvasSettingsProvider({ children }: { children: ReactNode }) {
   const [settings, setSettings] = useState<CanvasSettings>(defaultSettings);
 
   const updateSettings = (newSettings: Partial<CanvasSettings>) => {
-    setSettings((prev) => {
-      // 배경 이미지가 변경되는 경우 이전 blob URL 해제
-      if (
-        newSettings.backgroundImage !== undefined &&
-        prev.backgroundImage &&
-        prev.backgroundImage !== newSettings.backgroundImage &&
-        prev.backgroundImage.startsWith("blob:")
-      ) {
-        URL.revokeObjectURL(prev.backgroundImage);
-      }
-      return { ...prev, ...newSettings };
-    });
+    setSettings((prev) => ({ ...prev, ...newSettings }));
   };
 
   const resetSettings = () => {
-    if (
-      settings.backgroundImage &&
-      settings.backgroundImage.startsWith("blob:")
-    ) {
-      URL.revokeObjectURL(settings.backgroundImage);
-    }
     setSettings(defaultSettings);
   };
 

--- a/src/utils/fileToDataUrl.ts
+++ b/src/utils/fileToDataUrl.ts
@@ -1,0 +1,77 @@
+export async function fileToDataUrl(
+  file: File,
+  maxWidthOrHeight: number = 2000,
+  quality: number = 0.8,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = (e) => {
+      const dataUrl = e.target?.result as string;
+      if (!dataUrl) {
+        reject(new Error("FileReader failed"));
+        return;
+      }
+
+      // 이미지가 아닌 경우 원본 Data URL 반환 (보통 발생하지 않음)
+      if (!file.type.startsWith("image/")) {
+        resolve(dataUrl);
+        return;
+      }
+
+      // WebP, JPEG, PNG 등의 이미지인 경우 리사이즈/압축 수행
+      const img = new Image();
+      img.onload = () => {
+        let { width, height } = img;
+
+        // 크기 제한 계산 (비율 유지)
+        if (width > maxWidthOrHeight || height > maxWidthOrHeight) {
+          if (width > height) {
+            height = Math.round((height * maxWidthOrHeight) / width);
+            width = maxWidthOrHeight;
+          } else {
+            width = Math.round((width * maxWidthOrHeight) / height);
+            height = maxWidthOrHeight;
+          }
+        }
+
+        const canvas = document.createElement("canvas");
+        canvas.width = width;
+        canvas.height = height;
+
+        const ctx = canvas.getContext("2d");
+        if (!ctx) {
+          resolve(dataUrl); // 실패 시 원본 Data URL 반환
+          return;
+        }
+
+        // 투명도 등 유지를 위해 먼저 그려내기
+        ctx.drawImage(img, 0, 0, width, height);
+
+        // 출력 타입 결정: PNG는 WebP로 시도하여 용량 절감 (투명도 유지), 나머지는 JPEG 활용 (브라우저 호환성)
+        const outputType =
+          file.type === "image/png" ? "image/webp" : "image/jpeg";
+
+        try {
+          const compressedDataUrl = canvas.toDataURL(outputType, quality);
+          resolve(compressedDataUrl);
+        } catch (err) {
+          console.warn("Canvas export failed, falling back to original", err);
+          resolve(dataUrl); // 실패 시 원본 Data URL 반환
+        }
+      };
+
+      img.onerror = () => {
+        reject(new Error("Image processing failed"));
+      };
+
+      img.src = dataUrl;
+    };
+
+    reader.onerror = () => {
+      reject(new Error("FileReader processing failed"));
+    };
+
+    reader.readAsDataURL(file);
+  });
+}

--- a/src/utils/fileToDataUrl.ts
+++ b/src/utils/fileToDataUrl.ts
@@ -1,6 +1,6 @@
 export async function fileToDataUrl(
   file: File,
-  maxWidthOrHeight: number = 2000,
+  maxWidthOrHeight: number = 2500,
   quality: number = 0.8,
 ): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -48,9 +48,13 @@ export async function fileToDataUrl(
         // 투명도 등 유지를 위해 먼저 그려내기
         ctx.drawImage(img, 0, 0, width, height);
 
-        // 출력 타입 결정: PNG는 WebP로 시도하여 용량 절감 (투명도 유지), 나머지는 JPEG 활용 (브라우저 호환성)
+        // 출력 타입 결정: 투명화 이미지는 WebP로 시도, 나머지는 JPEG(GIF 미지원)
         const outputType =
-          file.type === "image/png" ? "image/webp" : "image/jpeg";
+          file.type === "image/png" ||
+          file.type === "image/webp" ||
+          file.type === "image/svg+xml"
+            ? "image/webp"
+            : "image/jpeg";
 
         try {
           const compressedDataUrl = canvas.toDataURL(outputType, quality);


### PR DESCRIPTION
## 개요

- 최종 이미지 저장 시 간헐적으로 오류가 발생하는 현상 수정

## 관련 이슈
- Closed #6 

## 상세 내용
- [오류 일지](https://capable-tip-b75.notion.site/334196eac98480b9b3edeaf2f43e5ea7?source=copy_link)
- html-to-image에서 fetch시 object url을 찾지 못해 저장이 불가한 현상을 막기 위해, 이미지 업로드 시 base64로 인코딩해 저장
- fetch 동작이 일어나지 않도록 하여 동일한 문제가 발생하지 않도록 조치

## 기타
- 대용량 이미지(16MB) 첨부 테스트 완료
- 개발 및 프로덕션 모두 본인 환경에서는 동일 오류 재현 불가, 따라서 문제 해결 여부를 확인하기 위해 지속적인 모니터링 필요

## 참고 문서

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 이미지 업로드 훅 도입으로 일관된 업로드 처리와 재시도 지원
  * 파일을 데이터 URL로 변환해 자동 리사이즈·압축 및 형식 변환 지원(WebP/JPEG)

* **개선 사항**
  * 업로드 성공/실패에 대한 중앙화된 처리로 안정성 향상
  * 실패 시 사용자 대상 한국어 알림 추가로 오류 인지 개선

* **변경**
  * 일부 로컬 객체 URL 정리 로직 단순화(내부 메모리 관리 변경)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->